### PR TITLE
Agregación venv a gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+neumonia-env
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
Se agregó la carpeta de entorno virtual con las librerías al .gitignore para que quede excluida al cargarla al repositorio.